### PR TITLE
ci: update runner to ubuntu-latest

### DIFF
--- a/.github/workflows/publish-to-production-pypi.yml
+++ b/.github/workflows/publish-to-production-pypi.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.7


### PR DESCRIPTION
[Publish action](https://github.com/introkun/qt-range-slider/actions/runs/5327933779) seems to have failed due to deprecated runner version. `ubuntu-18.04` has [been deprecated](https://github.com/actions/runner-images/issues/6002) this year.

I think manual publishing for versions that has not published to PyPI yet will be needed.